### PR TITLE
Add Major League Baseball login

### DIFF
--- a/data/list.toml
+++ b/data/list.toml
@@ -286,3 +286,9 @@
   url = "https://zoom.us/"
   description = "Only allows passwords of up to 32 characters in length."
 
+[[entity]]
+  name = "Major League Baseball"
+  plaintextPasswordFlag = false
+  url = "https://www.mlb.com/"
+  description = "Must be 8 - 15 characters. Disallows special characters and does not specify it."
+


### PR DESCRIPTION
I wouldn't know for sure that special characters are the problem except that the user creation page is different depending on context. When creating from buying a ticket portal (at least, for my local team), you are instructed "Not special characters." When making a user from the main MLB page, you are simply told "Please provide a valid password."